### PR TITLE
:sparkles: support deep equal with object inside array, object inside object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function strictArrayEquals(arr1, arr2) {
 		return false;
 	}
 
-	return arr1.every((item, index) => item === arr2[index]);
+	return arr1.every((item, index) => JSON.stringify(item) === JSON.stringify(arr2[index]));
 }
 
 module.exports = strictArrayEquals;

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -14,6 +14,26 @@ describe('strictArrayEquals', () => {
 		expect(strictArrayEquals(['a', 23], [42])).toBe(false);
 	});
 
+	it('should return true when arrays are strictly equal (object inside array)', () => {
+		expect(strictArrayEquals([{1: 'a'}, {2: 'b'}], [{1: 'a'}, {2: 'b'}])).toBe(true);
+		expect(strictArrayEquals([{numbers: [1, 3, 5]}, {numbers: [2, 4, 6]}], [{numbers: [1, 3, 5]}, {numbers: [2, 4, 6]}])).toBe(true);
+	});
+
+	it('should return false when arrays are not strictly equal (object inside array)', () => {
+		expect(strictArrayEquals([{1: 'a'}], [{1: 'b'}])).toBe(false);
+		expect(strictArrayEquals([{numbers: [1, 3, 5]}, {numbers: [2, 4, 6]}], [{numbers: [1, 3, 5]}])).toBe(false);
+	});
+
+	it('should return true when arrays are strictly equal (object inside object)', () => {
+		expect(strictArrayEquals([{1: {id: '1'}}], [{1: {id: '1'}}])).toBe(true);
+		expect(strictArrayEquals([{numbers: {1: 1, 2: 2}}], [{numbers: {1: 1, 2: 2}}])).toBe(true);
+	});
+
+	it('should return false when arrays are not strictly equal (object inside object)', () => {
+		expect(strictArrayEquals([{1: {id: '1'}}], [{1: {id: '2'}}])).toBe(false);
+		expect(strictArrayEquals([{numbers: {1: 1, 2: 2}}], [{numbers: {1: 1}}])).toBe(false);
+	});
+
 	it('should return false when only one array is provided as an argument', () => {
 		expect(strictArrayEquals(['a', 23])).toBe(false);
 	});


### PR DESCRIPTION
Add a new feature Deep equals on array

strictArrayEquals([{id: 1}], [{id: 1}]);  // true
strictArrayEquals([{array: [1,2,3,4]}], [{array: [1,2,3,4]}]);  // true

Your unit tests still working.